### PR TITLE
Address !67 - Add support for queries in unit values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,21 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <source>${version.jdk}</source>
+                        <target>${version.jdk}</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
     </build>
 
 </project>

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Byte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Byte.java
@@ -107,7 +107,7 @@ public final class Byte extends StorageUnit<Byte> {
     }
 
     @Override
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BigInteger.ONE;
     }
 
@@ -121,6 +121,11 @@ public final class Byte extends StorageUnit<Byte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return 0;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Exabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Exabyte.java
@@ -19,6 +19,8 @@ public final class Exabyte extends StorageUnit<Exabyte> {
     @Serial
     private static final long serialVersionUID = 6846441733771841250L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_EXABYTE);
+
     Exabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Exabyte extends StorageUnit<Exabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_EXABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Exabyte extends StorageUnit<Exabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Exbibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Exbibyte.java
@@ -19,6 +19,8 @@ public final class Exbibyte extends StorageUnit<Exbibyte> {
     @Serial
     private static final long serialVersionUID = 5993490571003918471L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_EXBIBYTE);
+
     Exbibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -38,7 +40,7 @@ public final class Exbibyte extends StorageUnit<Exbibyte> {
      */
     @CheckReturnValue
     public static @NotNull Exbibyte valueOf(final long numberOfBytes) {
-        return valueOf(BigInteger.valueOf(numberOfBytes));
+        return valueOf(java.math.BigInteger.valueOf(numberOfBytes));
     }
 
     /**
@@ -112,7 +114,7 @@ public final class Exbibyte extends StorageUnit<Exbibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_EXBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Exbibyte extends StorageUnit<Exbibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Gibibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Gibibyte.java
@@ -19,6 +19,8 @@ public final class Gibibyte extends StorageUnit<Gibibyte> {
     @Serial
     private static final long serialVersionUID = -1104749948510944566L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_GIBIBYTE);
+
     Gibibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Gibibyte extends StorageUnit<Gibibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BYTES_IN_A_GIBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Gibibyte extends StorageUnit<Gibibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Gigabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Gigabyte.java
@@ -19,6 +19,8 @@ public final class Gigabyte extends StorageUnit<Gigabyte> {
     @Serial
     private static final long serialVersionUID = 7581075190529125530L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_GIGABYTE);
+
     Gigabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Gigabyte extends StorageUnit<Gigabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BYTES_IN_A_GIGABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Gigabyte extends StorageUnit<Gigabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Kibibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Kibibyte.java
@@ -19,6 +19,8 @@ public final class Kibibyte extends StorageUnit<Kibibyte> {
     @Serial
     private static final long serialVersionUID = 3798828851496657978L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_KIBIBYTE);
+
     Kibibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Kibibyte extends StorageUnit<Kibibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_KIBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Kibibyte extends StorageUnit<Kibibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Kilobyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Kilobyte.java
@@ -19,6 +19,8 @@ public final class Kilobyte extends StorageUnit<Kilobyte> {
     @Serial
     private static final long serialVersionUID = 6952239416014811456L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_KILOBYTE);
+
     Kilobyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Kilobyte extends StorageUnit<Kilobyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BYTES_IN_A_KILOBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Kilobyte extends StorageUnit<Kilobyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Mebibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Mebibyte.java
@@ -19,6 +19,8 @@ public final class Mebibyte extends StorageUnit<Mebibyte> {
     @Serial
     private static final long serialVersionUID = 7697583678146919524L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_MEBIBYTE);
+
     Mebibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Mebibyte extends StorageUnit<Mebibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_MEBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Mebibyte extends StorageUnit<Mebibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Megabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Megabyte.java
@@ -19,6 +19,8 @@ public final class Megabyte extends StorageUnit<Megabyte> {
     @Serial
     private static final long serialVersionUID = 5901923092058760111L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_MEGABYTE);
+
     Megabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Megabyte extends StorageUnit<Megabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_MEGABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Megabyte extends StorageUnit<Megabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Pebibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Pebibyte.java
@@ -19,6 +19,8 @@ public final class Pebibyte extends StorageUnit<Pebibyte> {
     @Serial
     private static final long serialVersionUID = -6112472064345339882L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_PEBIBYTE);
+
     Pebibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Pebibyte extends StorageUnit<Pebibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_PEBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Pebibyte extends StorageUnit<Pebibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Petabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Petabyte.java
@@ -19,6 +19,8 @@ public final class Petabyte extends StorageUnit<Petabyte> {
     @Serial
     private static final long serialVersionUID = 5889808368085688387L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_PETABYTE);
+
     Petabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Petabyte extends StorageUnit<Petabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_PETABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Petabyte extends StorageUnit<Petabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Qubibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Qubibyte.java
@@ -19,6 +19,8 @@ public final class Qubibyte extends StorageUnit<Qubibyte> {
     @Serial
     private static final long serialVersionUID = 8611754914470986560L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_QUBIBYTE);
+
     Qubibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Qubibyte extends StorageUnit<Qubibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_QUBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Qubibyte extends StorageUnit<Qubibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Quettabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Quettabyte.java
@@ -19,6 +19,8 @@ public final class Quettabyte extends StorageUnit<Quettabyte> {
     @Serial
     private static final long serialVersionUID = -7866123408102424489L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_QUETTABYTE);
+
     Quettabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Quettabyte extends StorageUnit<Quettabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_QUETTABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Quettabyte extends StorageUnit<Quettabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Robibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Robibyte.java
@@ -19,6 +19,8 @@ public final class Robibyte extends StorageUnit<Robibyte> {
     @Serial
     private static final long serialVersionUID = 3553336770900659080L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_ROBIBYTE);
+
     Robibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Robibyte extends StorageUnit<Robibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_ROBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Robibyte extends StorageUnit<Robibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Ronnabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Ronnabyte.java
@@ -19,6 +19,8 @@ public final class Ronnabyte extends StorageUnit<Ronnabyte> {
     @Serial
     private static final long serialVersionUID = -7866123408102424489L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_RONNABYTE);
+
     Ronnabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Ronnabyte extends StorageUnit<Ronnabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_RONNABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Ronnabyte extends StorageUnit<Ronnabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Tebibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Tebibyte.java
@@ -19,6 +19,8 @@ public final class Tebibyte extends StorageUnit<Tebibyte> {
     @Serial
     private static final long serialVersionUID = 3614537130129620881L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_TEBIBYTE);
+
     Tebibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Tebibyte extends StorageUnit<Tebibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BYTES_IN_A_TEBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Tebibyte extends StorageUnit<Tebibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Terabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Terabyte.java
@@ -19,6 +19,8 @@ public final class Terabyte extends StorageUnit<Terabyte> {
     @Serial
     private static final long serialVersionUID = 2160488069631638952L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_TERABYTE);
+
     Terabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Terabyte extends StorageUnit<Terabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_TERABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Terabyte extends StorageUnit<Terabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Yobibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Yobibyte.java
@@ -19,6 +19,8 @@ public final class Yobibyte extends StorageUnit<Yobibyte> {
     @Serial
     private static final long serialVersionUID = -5606322878020884194L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_YOBIBYTE);
+
     Yobibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Yobibyte extends StorageUnit<Yobibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_YOBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Yobibyte extends StorageUnit<Yobibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Yottabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Yottabyte.java
@@ -19,6 +19,8 @@ public final class Yottabyte extends StorageUnit<Yottabyte> {
     @Serial
     private static final long serialVersionUID = 2482152459842042316L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_YOTTABYTE);
+
     Yottabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Yottabyte extends StorageUnit<Yottabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_YOTTABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Yottabyte extends StorageUnit<Yottabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Zebibyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Zebibyte.java
@@ -19,6 +19,8 @@ public final class Zebibyte extends StorageUnit<Zebibyte> {
     @Serial
     private static final long serialVersionUID = 2192254824473341887L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_ZEBIBYTE);
+
     Zebibyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Zebibyte extends StorageUnit<Zebibyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return StorageUnit.BYTES_IN_A_ZEBIBYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Zebibyte extends StorageUnit<Zebibyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::binaryValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/main/java/wtf/metio/storageunits/model/Zettabyte.java
+++ b/storage-units-model/src/main/java/wtf/metio/storageunits/model/Zettabyte.java
@@ -19,6 +19,8 @@ public final class Zettabyte extends StorageUnit<Zettabyte> {
     @Serial
     private static final long serialVersionUID = 8849006574018911826L;
 
+    private static final int conversionScale = computeFiniteConversionScale(StorageUnit.BYTES_IN_A_ZETTABYTE);
+
     Zettabyte(final @NotNull BigInteger numberOfBytes) {
         super(numberOfBytes);
     }
@@ -112,7 +114,7 @@ public final class Zettabyte extends StorageUnit<Zettabyte> {
 
     @Override
     @CheckReturnValue
-    protected @NotNull BigInteger getNumberOfBytesPerUnit() {
+    public @NotNull BigInteger getNumberOfBytesPerUnit() {
         return BYTES_IN_A_ZETTABYTE;
     }
 
@@ -126,6 +128,11 @@ public final class Zettabyte extends StorageUnit<Zettabyte> {
     @CheckReturnValue
     protected @NotNull Function<@NotNull BigInteger, @NotNull StorageUnit<?>> converter() {
         return StorageUnits::decimalValueOf;
+    }
+
+    @Override
+    protected int conversionScale() {
+        return conversionScale;
     }
 
 }

--- a/storage-units-model/src/test/java/wtf/metio/storageunits/model/StorageUnitArithmeticBigIntegerTest.java
+++ b/storage-units-model/src/test/java/wtf/metio/storageunits/model/StorageUnitArithmeticBigIntegerTest.java
@@ -8,12 +8,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.function.Function;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 class StorageUnitArithmeticBigIntegerTest {
 
+    private static final int WHOLE_TEST = 42;
     private static LongStream numberOfBytes() {
         return LongStream.of(1, 2, 3, 5, 8, 13, 100, 500, -500, 123456789);
     }
@@ -131,6 +136,59 @@ class StorageUnitArithmeticBigIntegerTest {
                         final var second = first.subtract(BigInteger.valueOf(100));
 
                         Assertions.assertNotSame(first, second, "The subtract(long) method must return a new instance.");
+                    });
+                });
+    }
+
+    @TestFactory
+    Stream<DynamicTest> getUnitValue() {
+
+        record D(Function<BigInteger, StorageUnit<?>> constructor, RoundingMode rm) {}
+
+        return Arrays.stream(RoundingMode.values()).flatMap(rm->
+                TestObjects.bigIntegerBasedConstructors().stream().map(e->new D(e, rm)))
+                .map(ti -> {
+                    final var initialAmount = BigInteger.valueOf(1);
+                    final var first = ti.constructor.apply(initialAmount);
+                    final var bpu = first.getNumberOfBytesPerUnit();
+                    final int digits = first.getNumberOfBytesPerUnit().toString().length();
+
+                    return DynamicTest.dynamicTest(String.format("getUnitValue() - %s - %s", first.getClass().getSimpleName(), ti.rm), () -> {
+
+                        // fill it up to the brim.
+                        StringBuilder sb = new StringBuilder(digits);
+                        for (int i = 0; i < digits; i++) { sb.append((char)(i%9+ '1')); }
+                        var testValue = new BigInteger(sb.toString());
+                        final var real = ti.constructor.apply(testValue);
+
+                        // do the math ourselves and compare? What else can we do.
+                        // scale value of 1000 - just something that's guaranteed to cover
+                        // all defined units, and isn't too large enough to slow JDK down
+                        var exp = new BigDecimal(testValue).divide(new BigDecimal(bpu), 1000, ti.rm).stripTrailingZeros();
+                        Assertions.assertEquals(exp, real.unitValue(ti.rm), ()->"unitValue() - "+ti.rm + " on "+testValue + ", bpu="+bpu +", scale="+real.conversionScale());
+
+                        // make sure we didn't miswire any of the implementations.
+                        Assertions.assertEquals(StorageUnit.computeFiniteConversionScale(bpu), real.conversionScale());
+
+                        if (ti.rm != RoundingMode.UNNECESSARY) {
+                            var wholeExp = new BigDecimal(testValue).divide(new BigDecimal(bpu), 0, ti.rm).toBigInteger();
+                            Assertions.assertEquals(wholeExp, real.wholeUnitValue(ti.rm), () -> "wholeUnitValue() - " + ti.rm + " on " + testValue + ", bpu=" + bpu + ", scale=" + real.conversionScale());
+                        }
+
+                        var remExp = testValue.remainder(bpu);
+                        Assertions.assertEquals(remExp, real.remainder());
+
+                        if (bpu.equals(BigInteger.ONE)) {
+                            Assertions.assertTrue(real.isWhole());
+                        } else {
+                            Assertions.assertFalse(real.isWhole());
+                            var whole = ti.constructor.apply(BigInteger.valueOf(WHOLE_TEST).multiply(bpu));
+                            Assertions.assertTrue(whole.isWhole());
+                            if (ti.rm == RoundingMode.UNNECESSARY) {
+                                Assertions.assertEquals(BigInteger.valueOf(WHOLE_TEST), whole.wholeUnitValue(ti.rm));
+                            }
+                        }
+
                     });
                 });
     }


### PR DESCRIPTION
This adds the following into a storage unit:

* unitValue() - get a measure of bytes in the unit of this storage unit. Kilobyte(4096).unitValue(UNNECESSARY) = 4.096. Rounding mode parameter is for those who'd implement their own units that are not even to a 10 or a 2.
* wholeUnitValue() - get a measure of bytes in the whole unit of this storage unit. Rounding mode specifies how to round, Kilobyte(4024).wholeUnitValue(RoundingMode.UP) = 5
* remainder() - get the remainder of bytes that didn't fit into a whole unit value, Kilobyte(4096).remainder() = 96.
* isWhole() - test whether the byte values fits into a whole unit, Kilobyte(4096).isWhole() = false, but for 1000 is true

I've changed the visibility of getNumberOfBytesPerUnit to `public`, as I don't see a reason of hiding this. For abstract processing of unit objects in code, this can be vital to know.

Tests added. Mvn verify passes.

I also altered the top-level pom.xml to specify the Java version that the compiler plugin must abide by.
I honestly did this so that IDEA picks up the right expectations on the source/target code level, which didn't work because it (IDEA) doesn't seem to know to run the property-populating plugin, but I still think it should be there, so the language level doesn't depend on the version of the JDK the code is compiled with.
